### PR TITLE
Change fieldservice to use UID

### DIFF
--- a/src/services/FieldService.php
+++ b/src/services/FieldService.php
@@ -117,20 +117,20 @@ class FieldService extends Component
 
         // when reached folder already is the root folder
         if (empty($folder->parentId)) {
-            $tree[] = 'folder:' . $folder->id;
+            $tree[] = 'folder:' . $folder->uid;
         } else {
 
             $rootFolder = \Craft::$app->getAssets()->getRootFolderByVolumeId($folder->volumeId);
-            $tree[] = 'folder:' . $rootFolder->id;
+            $tree[] = 'folder:' . $rootFolder->uid;
 
             $folderTree = \Craft::$app->getAssets()->getFolderTreeByFolderId($folder->id);
             foreach ($folderTree as $folder) {
 
-                $tree[] = 'folder:' . $folder->id;
+                $tree[] = 'folder:' . $folder->uid;
             }
         }
 
-        // return folder tree like 'folder:1/folder:2/folder:3' etc.
+        // return folder tree like 'folder:<uid>/folder:<uid>/folder:<uid>' etc.
         return implode('/', $tree);
     }
 


### PR DESCRIPTION
Craft 3.1 recommends using UID instead of ID, because ID's are environment specific, UID's are not.

https://craftcms.com/guides/updating-plugins-for-craft-3-1#store-uIDs-instead-of-iDs

The images and files dialog would not work correctly using id's for me in craft 3.1, this fixed that.

Another thing I found after #7 was fixed.