### PR TITLE
Fix `Call to a member function getSettings() on null`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "hasSettings": true,
     "developer": "Bert Oost",
     "developerUrl": "https://bertoost.com",
-    "documentationUrl": "https://github.com/froala/Craft-3-Froala-WYSIWYG/blob/master/README.md",
-    "class": "froala\\craftfroalawysiwyg\\Plugin"
+    "documentationUrl": "https://github.com/froala/Craft-3-Froala-WYSIWYG/blob/master/README.md"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
     "developer": "Bert Oost",
     "developerUrl": "https://bertoost.com",
     "documentationUrl": "https://github.com/froala/Craft-3-Froala-WYSIWYG/blob/master/README.md",
-    "class": "froala\\craftfroalawysiwyg\\FroalaEditor",
+    "class": "froala\\craftfroalawysiwyg\\FroalaEditor"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "hasSettings": true,
     "developer": "Bert Oost",
     "developerUrl": "https://bertoost.com",
-    "documentationUrl": "https://github.com/froala/Craft-3-Froala-WYSIWYG/blob/master/README.md"
+    "documentationUrl": "https://github.com/froala/Craft-3-Froala-WYSIWYG/blob/master/README.md",
+    "class": "froala\\craftfroalawysiwyg\\FroalaEditor",
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
     "developer": "Bert Oost",
     "developerUrl": "https://bertoost.com",
     "documentationUrl": "https://github.com/froala/Craft-3-Froala-WYSIWYG/blob/master/README.md",
-    "class": "froala\\craftfroalawysiwyg\\FroalaEditor"
+    "class": "froala\\craftfroalawysiwyg\\Plugin"
   }
 }

--- a/src/Field.php
+++ b/src/Field.php
@@ -317,6 +317,6 @@ class Field extends \craft\base\Field
      */
     private function getPluginSettings()
     {
-        return FroalaEditor::getInstance()->getSettings();
+        return Plugin::getInstance()->getSettings();
     }
 }

--- a/src/Field.php
+++ b/src/Field.php
@@ -46,21 +46,6 @@ class Field extends \craft\base\Field
     public $editorConfig = '';
 
     /**
-     * @var \craft\base\Model
-     */
-    private $pluginSettings;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function init()
-    {
-        parent::init();
-
-        $this->pluginSettings = Plugin::getInstance()->getSettings();
-    }
-
-    /**
      * {@inheritdoc}
      */
     public static function displayName(): string
@@ -75,7 +60,7 @@ class Field extends \craft\base\Field
     {
         return Craft::$app->getView()->renderTemplate('froala-editor/field/settings', [
             'field'               => $this,
-            'pluginSettings'      => $this->pluginSettings,
+            'pluginSettings'      => $this->getPluginSettings(),
             'editorConfigOptions' => Plugin::getInstance()->getCustomConfigOptions('froalaeditor'),
         ]);
     }
@@ -106,7 +91,7 @@ class Field extends \craft\base\Field
             $fieldService = Plugin::getInstance()->getFieldService();
             $fieldService->setElement($element);
 
-            $pluginSettings = $this->pluginSettings->toArray();
+            $pluginSettings = $this->getPluginSettings()->toArray();
 
             // start input editor settings
             $site = ($element ? $element->getSite() : Craft::$app->getSites()->currentSite);
@@ -197,14 +182,14 @@ class Field extends \craft\base\Field
         // Get the raw value
         $value = $value->getRawContent();
 
-        if ($this->pluginSettings->purifyHtml) {
+        if ($this->getPluginSettings()->purifyHtml) {
             // Parse reference tags so HTMLPurifier doesn't encode the curly braces
             $value = $this->_parseRefs($value, $element);
 
             $value = HtmlPurifier::process($value, $this->getPurifierConfig());
         }
 
-        if ($this->pluginSettings->cleanupHtml) {
+        if ($this->getPluginSettings()->cleanupHtml) {
 
             // Remove <span> and <font> tags
             $value = preg_replace('/<(?:span|font)\b[^>]*>/', '', $value);
@@ -292,7 +277,7 @@ class Field extends \craft\base\Field
      */
     private function getPurifierConfig(): array
     {
-        if ($config = $this->getConfig('htmlpurifier', $this->pluginSettings->purifierConfig)) {
+        if ($config = $this->getConfig('htmlpurifier', $this->getPluginSettings()->purifierConfig)) {
             return $config;
         }
 
@@ -323,5 +308,15 @@ class Field extends \craft\base\Field
         }
 
         return Json::decode(file_get_contents($path));
+    }
+
+    /**
+     * Returns plugin settings.
+     *
+     * @return array|null
+     */
+    private function getPluginSettings()
+    {
+        return FroalaEditor::getInstance()->getSettings();
     }
 }


### PR DESCRIPTION
Fixes issue #11 with `Call to a member function getSettings() on null` bug, that can sometimes be triggered.

**Recommend additional testing before accepting this PR, as I'm the single tester so far** 